### PR TITLE
feat: patpass comercio

### DIFF
--- a/src/main/java/cl/transbank/webpay/example/controllers/BaseController.java
+++ b/src/main/java/cl/transbank/webpay/example/controllers/BaseController.java
@@ -1,5 +1,6 @@
 package cl.transbank.webpay.example.controllers;
 
+import cl.transbank.exception.TransbankException;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonPrimitive;
 import com.google.gson.JsonSerializer;
@@ -8,6 +9,8 @@ import java.math.BigDecimal;
 import java.util.Random;
 
 public abstract class BaseController {
+    private static final String GENERIC_ERROR_MESSAGE =
+            "Ocurrió un error inesperado al procesar la operación.";
 
     protected static final String VIEW_ERROR = "error/error_page";
     protected static final String VIEW_ABORTED_ERROR = "error/webpay/aborted";
@@ -34,5 +37,16 @@ public abstract class BaseController {
 
     protected String getRandomNumber() {
         return String.valueOf(new Random().nextInt(Integer.MAX_VALUE));
+    }
+
+    protected String getDisplayableErrorMessage(Exception e) {
+        Throwable current = e;
+        while (current != null) {
+            if (current instanceof TransbankException && current.getMessage() != null && !current.getMessage().isBlank()) {
+                return current.getMessage();
+            }
+            current = current.getCause();
+        }
+        return GENERIC_ERROR_MESSAGE;
     }
 }

--- a/src/main/java/cl/transbank/webpay/example/controllers/OneclickMallController.java
+++ b/src/main/java/cl/transbank/webpay/example/controllers/OneclickMallController.java
@@ -279,7 +279,7 @@ public class OneclickMallController extends BaseController {
     @ExceptionHandler(Exception.class)
     public String handleException(Exception e, Model model) {
         log.error("Error inesperado", e);
-        model.addAttribute("error", e.getMessage());
+        model.addAttribute("error", getDisplayableErrorMessage(e));
         return VIEW_ERROR;
     }
 }

--- a/src/main/java/cl/transbank/webpay/example/controllers/OneclickMallDeferredController.java
+++ b/src/main/java/cl/transbank/webpay/example/controllers/OneclickMallDeferredController.java
@@ -299,7 +299,7 @@ public class OneclickMallDeferredController extends BaseController {
     @ExceptionHandler(Exception.class)
     public String handleException(Exception e, Model model) {
         log.error("Error inesperado", e);
-        model.addAttribute("error", e.getMessage());
+        model.addAttribute("error", getDisplayableErrorMessage(e));
         return VIEW_ERROR;
     }
 }

--- a/src/main/java/cl/transbank/webpay/example/controllers/PatpassComercioController.java
+++ b/src/main/java/cl/transbank/webpay/example/controllers/PatpassComercioController.java
@@ -1,0 +1,251 @@
+package cl.transbank.webpay.example.controllers;
+
+import cl.transbank.common.IntegrationApiKeys;
+import cl.transbank.common.IntegrationCommerceCodes;
+import cl.transbank.patpass.PatpassComercio;
+import cl.transbank.patpass.responses.PatpassComercioInscriptionStartResponse;
+import cl.transbank.patpass.responses.PatpassComercioTransactionStatusResponse;
+import cl.transbank.webpay.exception.InscriptionStartException;
+import cl.transbank.webpay.exception.TransactionStatusException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpSession;
+import lombok.extern.log4j.Log4j2;
+import org.springframework.stereotype.Controller;
+import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+
+import java.io.IOException;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+@Log4j2
+@Controller
+@RequestMapping("/patpass-comercio")
+public class PatpassComercioController extends BaseController {
+    private static final String TEMPLATE_FOLDER = "patpass_comercio";
+    private static final String BASE_URL = "/patpass-comercio";
+    private static final String PRODUCT = "Patpass Comercio";
+    private static final String SESSION_TOKEN_KEY = "patpass_j_token";
+    private static final String DEFAULT_VOUCHER_URL =
+            "https://pagoautomaticocontarjetasint.transbank.cl/nuevo-ic-rest/tokenVoucherLogin";
+
+    private static final String COMMIT_PATH = "/commit";
+    private static final String VOUCHER_PATH = "/voucher";
+    private static final String NAVIGATION_ATTR = "navigation";
+    private static final String VOUCHER_URL = "voucherUrl";
+    private static final String ERROR_ATTR = "error";
+    private static final String VIEW_START = TEMPLATE_FOLDER + "/start";
+    private static final String VIEW_COMMIT = TEMPLATE_FOLDER + COMMIT_PATH;
+    private static final String VIEW_VOUCHER = TEMPLATE_FOLDER + VOUCHER_PATH;
+
+    private static final Map<String, String> NAV_START;
+    private static final Map<String, String> NAV_COMMIT;
+    private static final Map<String, String> NAV_VOUCHER;
+
+    static {
+        NAV_START = new LinkedHashMap<>();
+        NAV_START.put("request", "Petición");
+        NAV_START.put("response", "Respuesta");
+        NAV_START.put("form", "Formulario");
+        NAV_START.put("example", "Ejemplo");
+
+        NAV_COMMIT = new LinkedHashMap<>();
+        NAV_COMMIT.put("data", "Datos recibidos");
+        NAV_COMMIT.put("request", "Petición");
+        NAV_COMMIT.put("response", "Respuesta");
+        NAV_COMMIT.put("form", "Formulario");
+
+        NAV_VOUCHER = new LinkedHashMap<>();
+        NAV_VOUCHER.put("form", "voucher");
+    }
+
+    private final PatpassComercio.Inscription inscription;
+
+    public PatpassComercioController() {
+        this.inscription = PatpassComercio.Inscription.buildForIntegration(
+                IntegrationCommerceCodes.PATPASS_COMERCIO,
+                IntegrationApiKeys.PATPASS_COMERCIO
+        );
+    }
+
+    private void addBreadcrumbs(Model model, String label, String url) {
+        Map<String, String> breadcrumbs = new LinkedHashMap<>();
+        breadcrumbs.put("Inicio", "/");
+        breadcrumbs.put(PRODUCT, BASE_URL);
+        if (label != null) {
+            breadcrumbs.put(label, url);
+        }
+        model.addAttribute("product", PRODUCT);
+        model.addAttribute("breadcrumbs", breadcrumbs);
+    }
+
+    @GetMapping({"", "/"})
+    public String start(HttpServletRequest request, Model model)
+            throws IOException, InscriptionStartException {
+        model.addAttribute(NAVIGATION_ATTR, NAV_START);
+        addBreadcrumbs(model, null, null);
+
+        String returnUrl = request.getRequestURL().toString().replaceAll("/?$", "") + COMMIT_PATH;
+        String finalUrl = request.getRequestURL().toString().replaceAll("/?$", "") + VOUCHER_PATH;
+
+        Map<String, Object> requestData = new LinkedHashMap<>();
+        requestData.put("serviceId", "Service-" + getRandomNumber());
+        requestData.put("maxAmount", 100);
+        requestData.put("returnUrl", returnUrl);
+        requestData.put("finalUrl", finalUrl);
+        requestData.put("name", "Isaac");
+        requestData.put("lastName", "Newton");
+        requestData.put("secondLastName", "Gonzales");
+        requestData.put("rut", "11111111-1");
+        requestData.put("phone", "123456734");
+        requestData.put("cellPhone", "123456723");
+        requestData.put("patpassName", "Membresia de cable");
+        requestData.put("personEmail", "developer@continuum.cl");
+        requestData.put("commerceEmail", "developer@continuum.cl");
+        requestData.put("address", "Satelite 101");
+        requestData.put("city", "Santiago");
+
+
+        PatpassComercioInscriptionStartResponse resp = this.inscription.start(
+                requestData.get("returnUrl").toString(),
+                requestData.get("name").toString(),
+                requestData.get("lastName").toString(),
+                requestData.get("secondLastName").toString(),
+                requestData.get("rut").toString(),
+                requestData.get("serviceId").toString(),
+                requestData.get("finalUrl").toString(),
+                Double.valueOf(requestData.get("maxAmount").toString()),
+                requestData.get("phone").toString(),
+                requestData.get("cellPhone").toString(),
+                requestData.get("patpassName").toString(),
+                requestData.get("personEmail").toString(),
+                requestData.get("commerceEmail").toString(),
+                requestData.get("address").toString(),
+                requestData.get("city").toString()
+        );
+
+        model.addAttribute("request_data", requestData);
+        model.addAttribute("response_data", resp);
+        model.addAttribute("response_data_json", toJson(resp));
+        return VIEW_START;
+    }
+
+    @PostMapping("/commit")
+    public String commitPost(@RequestParam(name = "j_token", required = false) String jTokenLower,
+                             @RequestParam(name = "J_TOKEN", required = false) String jTokenUpper,
+                             @RequestParam(name = "token", required = false) String token,
+                             HttpServletRequest request,
+                             Model model) {
+        String jToken = firstNonBlank(jTokenLower, jTokenUpper, token);
+        if (isBlank(jToken)) {
+            model.addAttribute(ERROR_ATTR, "No se recibió el token de inscripción (J_TOKEN).");
+            return VIEW_ERROR;
+        }
+
+        request.getSession().setAttribute(SESSION_TOKEN_KEY, jToken);
+        return "redirect:" + BASE_URL + COMMIT_PATH;
+    }
+
+    @GetMapping(COMMIT_PATH)
+    public String commit(@RequestParam(name = "j_token", required = false) String jTokenLower,
+                         @RequestParam(name = "J_TOKEN", required = false) String jTokenUpper,
+                         @RequestParam(name = "token", required = false) String token,
+                         HttpServletRequest request,
+                         Model model)
+            throws IOException, TransactionStatusException {
+        String jToken = getIncomingToken(request.getSession(), jTokenLower, jTokenUpper, token);
+        if (isBlank(jToken)) {
+            model.addAttribute(ERROR_ATTR, "No se encontró el token de inscripción (J_TOKEN).");
+            return VIEW_ERROR;
+        }
+
+        model.addAttribute(NAVIGATION_ATTR, NAV_COMMIT);
+        addBreadcrumbs(model, "Confirmar registro", BASE_URL + COMMIT_PATH);
+
+        PatpassComercioTransactionStatusResponse resp = inscription.status(jToken);
+        request.getSession().setAttribute(SESSION_TOKEN_KEY, jToken);
+
+        model.addAttribute("token", jToken);
+        model.addAttribute("response_data", resp);
+        model.addAttribute("response_data_json", toJson(resp));
+        model.addAttribute("response_payload_json", toJson(Map.of(
+                "authorized", resp.isAuthorized(),
+                VOUCHER_URL, resp.getVoucherUrl()
+        )));
+        model.addAttribute(VOUCHER_URL,
+                isBlank(resp.getVoucherUrl()) ? DEFAULT_VOUCHER_URL : resp.getVoucherUrl());
+
+        return VIEW_COMMIT;
+    }
+
+    @PostMapping(VOUCHER_PATH)
+    public String voucherPost(@RequestParam(name = "j_token", required = false) String jTokenLower,
+                              @RequestParam(name = "J_TOKEN", required = false) String jTokenUpper,
+                              @RequestParam(name = "tokenComercio", required = false) String tokenComercio,
+                              @RequestParam(name = "token", required = false) String token,
+                              HttpServletRequest request,
+                              Model model) {
+        String jToken = firstNonBlank(jTokenLower, jTokenUpper, tokenComercio, token);
+        if (isBlank(jToken)) {
+            model.addAttribute(ERROR_ATTR, "No se recibió el token de inscripción (J_TOKEN).");
+            return VIEW_ERROR;
+        }
+
+        request.getSession().setAttribute(SESSION_TOKEN_KEY, jToken);
+        return "redirect:" + BASE_URL + VOUCHER_PATH;
+    }
+
+    @GetMapping(VOUCHER_PATH)
+    public String voucher(@RequestParam(name = "j_token", required = false) String jTokenLower,
+                          @RequestParam(name = "J_TOKEN", required = false) String jTokenUpper,
+                          @RequestParam(name = "tokenComercio", required = false) String tokenComercio,
+                          @RequestParam(name = "token", required = false) String token,
+                          HttpServletRequest request,
+                          Model model) {
+        String jToken = getIncomingToken(request.getSession(), jTokenLower, jTokenUpper, tokenComercio, token);
+        if (isBlank(jToken)) {
+            model.addAttribute(ERROR_ATTR, "No se encontró el token de inscripción (J_TOKEN).");
+            return VIEW_ERROR;
+        }
+
+        model.addAttribute(NAVIGATION_ATTR, NAV_VOUCHER);
+        addBreadcrumbs(model, "Voucher", BASE_URL + VOUCHER_PATH);
+        model.addAttribute("token", jToken);
+        model.addAttribute(VOUCHER_URL, DEFAULT_VOUCHER_URL);
+
+        return VIEW_VOUCHER;
+    }
+
+    private String getIncomingToken(HttpSession session, String... values) {
+        String token = firstNonBlank(values);
+        if (!isBlank(token)) {
+            return token;
+        }
+        Object sessionToken = session.getAttribute(SESSION_TOKEN_KEY);
+        return sessionToken == null ? null : sessionToken.toString();
+    }
+
+    private String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (!isBlank(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
+    }
+
+    @ExceptionHandler(Exception.class)
+    public String handleException(Exception e, Model model) {
+        log.error("Error inesperado", e);
+        model.addAttribute(ERROR_ATTR, e.getMessage());
+        return VIEW_ERROR;
+    }
+}

--- a/src/main/java/cl/transbank/webpay/example/controllers/PatpassComercioController.java
+++ b/src/main/java/cl/transbank/webpay/example/controllers/PatpassComercioController.java
@@ -245,7 +245,7 @@ public class PatpassComercioController extends BaseController {
     @ExceptionHandler(Exception.class)
     public String handleException(Exception e, Model model) {
         log.error("Error inesperado", e);
-        model.addAttribute(ERROR_ATTR, e.getMessage());
+        model.addAttribute(ERROR_ATTR, getDisplayableErrorMessage(e));
         return VIEW_ERROR;
     }
 }

--- a/src/main/java/cl/transbank/webpay/example/controllers/TransaccionCompletaController.java
+++ b/src/main/java/cl/transbank/webpay/example/controllers/TransaccionCompletaController.java
@@ -209,7 +209,7 @@ public class TransaccionCompletaController extends BaseController {
     @ExceptionHandler(Exception.class)
     public String handleException(Exception e, Model model) {
         log.error("Error inesperado", e);
-        model.addAttribute(ATTR_ERROR, e.getMessage());
+        model.addAttribute(ATTR_ERROR, getDisplayableErrorMessage(e));
         return VIEW_ERROR;
     }
 }

--- a/src/main/java/cl/transbank/webpay/example/controllers/TransaccionCompletaDiferidaController.java
+++ b/src/main/java/cl/transbank/webpay/example/controllers/TransaccionCompletaDiferidaController.java
@@ -238,7 +238,7 @@ public class TransaccionCompletaDiferidaController extends BaseController {
     @ExceptionHandler(Exception.class)
     public String handleException(Exception e, Model model) {
         log.error("Error inesperado", e);
-        model.addAttribute(ATTR_ERROR, e.getMessage());
+        model.addAttribute(ATTR_ERROR, getDisplayableErrorMessage(e));
         return VIEW_ERROR;
     }
 }

--- a/src/main/java/cl/transbank/webpay/example/controllers/TransaccionCompletaMallController.java
+++ b/src/main/java/cl/transbank/webpay/example/controllers/TransaccionCompletaMallController.java
@@ -276,7 +276,7 @@ public class TransaccionCompletaMallController extends BaseController {
 
     @ExceptionHandler(Exception.class)
     public String handleException(Exception e, Model model) {
-        model.addAttribute(ATTR_ERROR, e.getMessage());
+        model.addAttribute(ATTR_ERROR, getDisplayableErrorMessage(e));
         return VIEW_ERROR;
     }
 }

--- a/src/main/java/cl/transbank/webpay/example/controllers/TransaccionCompletaMallDiferidoController.java
+++ b/src/main/java/cl/transbank/webpay/example/controllers/TransaccionCompletaMallDiferidoController.java
@@ -302,7 +302,7 @@ public class TransaccionCompletaMallDiferidoController extends BaseController {
 
     @ExceptionHandler(Exception.class)
     public String handleException(Exception e, Model model) {
-        model.addAttribute(ATTR_ERROR, e.getMessage());
+        model.addAttribute(ATTR_ERROR, getDisplayableErrorMessage(e));
         return VIEW_ERROR;
     }
 }

--- a/src/main/java/cl/transbank/webpay/example/controllers/WebpayPlusController.java
+++ b/src/main/java/cl/transbank/webpay/example/controllers/WebpayPlusController.java
@@ -175,7 +175,7 @@ public class WebpayPlusController extends BaseController {
     @ExceptionHandler(Exception.class)
     public String handleException(Exception e, Model model) {
         log.error("Error inesperado", e);
-        model.addAttribute("error", e.getMessage());
+        model.addAttribute("error", getDisplayableErrorMessage(e));
         return VIEW_ERROR;
     }
 

--- a/src/main/java/cl/transbank/webpay/example/controllers/WebpayPlusDeferredController.java
+++ b/src/main/java/cl/transbank/webpay/example/controllers/WebpayPlusDeferredController.java
@@ -195,7 +195,7 @@ public class WebpayPlusDeferredController extends BaseController {
     @ExceptionHandler(Exception.class)
     public String handleException(Exception e, Model model) {
         log.error("Error inesperado", e);
-        model.addAttribute("error", e.getMessage());
+        model.addAttribute("error", getDisplayableErrorMessage(e));
         return VIEW_ERROR;
     }
 }

--- a/src/main/java/cl/transbank/webpay/example/controllers/WebpayPlusMallController.java
+++ b/src/main/java/cl/transbank/webpay/example/controllers/WebpayPlusMallController.java
@@ -200,7 +200,7 @@ public class WebpayPlusMallController extends BaseController {
     @ExceptionHandler(Exception.class)
     public String handleException(Exception e, Model model) {
         log.error("Error inesperado", e);
-        model.addAttribute("error", e.getMessage());
+        model.addAttribute("error", getDisplayableErrorMessage(e));
         return VIEW_ERROR;
     }
 

--- a/src/main/java/cl/transbank/webpay/example/controllers/WebpayPlusMallDeferredController.java
+++ b/src/main/java/cl/transbank/webpay/example/controllers/WebpayPlusMallDeferredController.java
@@ -233,7 +233,7 @@ public class WebpayPlusMallDeferredController extends BaseController {
     @ExceptionHandler(Exception.class)
     public String handleException(Exception e, Model model) {
         log.error("Error inesperado", e);
-        model.addAttribute("error", e.getMessage());
+        model.addAttribute("error", getDisplayableErrorMessage(e));
         return VIEW_ERROR;
     }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,2 @@
 spring.application.name=transbank-sdk-java-example
+server.forward-headers-strategy=framework

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,2 +1,1 @@
 spring.application.name=transbank-sdk-java-example
-server.forward-headers-strategy=framework

--- a/src/main/resources/templates/patpass_comercio/commit.html
+++ b/src/main/resources/templates/patpass_comercio/commit.html
@@ -1,0 +1,55 @@
+<div th:replace="~{layout :: layout(~{::content})}">
+    <div th:fragment="content">
+        <h1>Patpass Comercio - Confirmar Registro</h1>
+        <p class="mb-32">
+            Es necesario confirmar el registro; este solo se puede hacer una sola vez o retornará error.
+        </p>
+
+        <h2 id="data">Paso 1: Datos recibidos</h2>
+        <p class="mb-32">
+            Luego de que se termina el flujo en el formulario de inscripción recibirás un POST con la siguiente respuesta.
+        </p>
+
+        <pre><code class="language-json mb-32">
+{
+  "J_TOKEN": "<span th:text="${token}"></span>"
+}
+        </code></pre>
+
+        <h2 id="request">Paso 2: Petición</h2>
+        <p class="mb-32">
+            Usarás el token recibido para confirmar la inscripción usando el método status de PatpassComercio.
+        </p>
+
+        <pre><code class="language-java mb-32">
+var response = inscription.status(token);
+        </code></pre>
+
+        <h2 id="response">Paso 3: Respuesta</h2>
+        <p class="mb-32">
+            Transbank contestará con lo siguiente. Debes guardar esta información; lo importante es validar que
+            el atributo authorized sea igual a true.
+        </p>
+
+        <pre><code class="language-json mb-32" th:text="${response_payload_json}"></code></pre>
+
+        <h2 id="form">¡Listo!</h2>
+        <p class="mb-32">
+            Una vez realizada la inscripción y confirmada, puedes visualizar el voucher.
+        </p>
+
+        <div class="tbk-card">
+            <span class="tbk-card-title">Formulario de redirección</span>
+            <div class="input-container mb-32">
+                <label for="tokenComercio" class="tbk-label">Token</label>
+                <input type="text" id="tokenComercio" class="tbk-input-text" th:value="${token}" disabled />
+            </div>
+            <div class="tbk-card-footer">
+                <form th:action="${voucherUrl}" method="POST">
+                    <input type="hidden" name="tokenComercio" th:value="${token}">
+                    <button class="tbk-button primary">VER VOUCHER</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>

--- a/src/main/resources/templates/patpass_comercio/start.html
+++ b/src/main/resources/templates/patpass_comercio/start.html
@@ -1,0 +1,89 @@
+<div th:replace="~{layout :: layout(~{::content})}">
+    <div th:fragment="content">
+        <h1>Patpass Comercio - Iniciar Transacción</h1>
+        <p class="mb-16">
+            En este paso inicial, procederemos a inscribir una tarjeta con el objetivo de obtener un identificador único.
+            Esto nos permitirá redirigir al Tarjetahabiente hacia el formulario de inscripción en el siguiente paso.
+        </p>
+
+        <p class="mb-32">
+            Todas las transacciones de este proyecto ejemplo son realizadas en ambiente de integración.
+        </p>
+
+        <h2 id="request">Paso 1: Petición</h2>
+        <p class="mb-32">
+            Para comenzar, importa la librería PatpassComercio y luego inicia una inscripción. Tener en cuenta:
+            el ambiente de integración no admite direcciones locales en los atributos <code>url</code> y <code>finalUrl</code>.
+        </p>
+
+        <pre><code class="language-java mb-32">
+import cl.transbank.common.IntegrationApiKeys;
+import cl.transbank.common.IntegrationCommerceCodes;
+import cl.transbank.patpass.PatpassComercio;
+
+var inscription = PatpassComercio.Inscription.buildForIntegration(
+    IntegrationCommerceCodes.PATPASS_COMERCIO,
+    IntegrationApiKeys.PATPASS_COMERCIO
+);
+
+var resp = inscription.start(
+    returnUrl,
+    name,
+    lastName,
+    secondLastName,
+    rut,
+    serviceId,
+    finalUrl,
+    maxAmount,
+    phone,
+    cellPhone,
+    patpassName,
+    personEmail,
+    commerceEmail,
+    address,
+    city
+);
+        </code></pre>
+
+        <h2 id="response">Paso 2: Respuesta</h2>
+        <p class="mb-32">
+            Una vez iniciada la inscripción, recibirás los siguientes datos de respuesta:
+        </p>
+
+        <pre><code class="language-json mb-32" th:text="${response_data_json}"></code></pre>
+
+        <h2 id="form">Paso 3: Creación del formulario</h2>
+        <p class="mb-32">
+            Utiliza los datos obtenidos durante la inscripción para generar un formulario, proporcionando al
+            Tarjetahabiente una experiencia de inscripción fluida y segura.
+        </p>
+
+        <pre><code class="language-html mb-32"
+ th:text="'<form action=&quot;' + ${response_data.url} + '&quot; method=&quot;POST&quot;>
+  <input type=&quot;hidden&quot; name=&quot;tokenComercio&quot; value=&quot;' + ${response_data.token} + '&quot; />
+  <input type=&quot;submit&quot; value=&quot;Inscribir&quot; />
+</form>'">
+</code></pre>
+
+        <h2 id="example">Ejemplo</h2>
+        <p class="mb-32">
+            Para poder iniciar la inscripción, se necesitan los siguientes datos:
+        </p>
+
+        <div th:replace="~{partials/table :: table(${request_data})}"></div>
+
+        <form th:action="${response_data.url}" method="POST">
+            <div class="tbk-card">
+                <span class="tbk-card-title">Formulario de redirección</span>
+                <div class="input-container mb-32">
+                    <label for="tokenComercio" class="tbk-label">Token</label>
+                    <input type="text" id="tokenComercio" class="tbk-input-text" th:value="${response_data.token}" disabled />
+                    <input type="hidden" name="tokenComercio" th:value="${response_data.token}" />
+                </div>
+                <div class="tbk-card-footer">
+                    <button class="tbk-button primary">INSCRIBIR</button>
+                </div>
+            </div>
+        </form>
+    </div>
+</div>

--- a/src/main/resources/templates/patpass_comercio/voucher.html
+++ b/src/main/resources/templates/patpass_comercio/voucher.html
@@ -1,0 +1,22 @@
+<div th:replace="~{layout :: layout(~{::content})}">
+    <div th:fragment="content">
+        <h1>Patpass Comercio - Voucher</h1>
+        <p class="mb-32">
+            La inscripción ya se encuentra finalizada. Una vez finalizada la inscripción puedes seguir consultando por el voucher.
+        </p>
+
+        <div id="form" class="tbk-card">
+            <span class="tbk-card-title">Voucher</span>
+            <div class="input-container mb-32">
+                <label for="tokenComercio" class="tbk-label">Token</label>
+                <input type="text" id="tokenComercio" class="tbk-input-text" th:value="${token}" disabled />
+            </div>
+            <div class="tbk-card-footer">
+                <form th:action="${voucherUrl}" method="POST">
+                    <input type="hidden" name="tokenComercio" th:value="${token}">
+                    <button class="tbk-button primary">VER VOUCHER</button>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>


### PR DESCRIPTION
This pull request introduces two new controllers, `PatpassComercioController` and `TransaccionCompletaController`, significantly expanding the application's support for Patpass Comercio and Webpay Transacción Completa flows. Additionally, it updates the base JSON serialization logic to improve the handling of `Double` values.

<img width="1114" height="713" alt="image" src="https://github.com/user-attachments/assets/260ef329-8fa8-4901-93bf-d0a427815dfc" />
<img width="970" height="705" alt="image" src="https://github.com/user-attachments/assets/84ec39d9-492a-4c29-a39b-4b4a2fdaf12a" />
<img width="917" height="440" alt="image" src="https://github.com/user-attachments/assets/be01301a-62e6-4434-96c5-c83861c3ba63" />
