### PR TITLE
fix: add formatting to general error details in error page

### DIFF
--- a/src/main/resources/templates/error/error_page.html
+++ b/src/main/resources/templates/error/error_page.html
@@ -5,14 +5,14 @@
             <h1>¡Ups! Algo salió mal</h1>
             <p class="mb-32">Lo sentimos, ha ocurrido un error inesperado. Si el problema persiste comunícate con
                 nosotros en
-                nuestro canal de <a class="tbk-link" href="https://invitacion-slack.transbankdevelopers.cl/slack_community"
-                                    target="_blank">slack</a>
+                nuestro canal de <a class="tbk-link"
+                    href="https://invitacion-slack.transbankdevelopers.cl/slack_community" target="_blank">slack</a>
             </p>
 
             <div class="table-column mb-32" th:if="${error}">
                 <p>Detalles del error (solo para depuración):</p>
                 <div class="error-details">
-                    <div class="error-details" th:text="${error}"></div>
+                    <pre><code class="language-java" th:text="${error}"></code></pre>
                 </div>
             </div>
 


### PR DESCRIPTION
This PR add formatting to general error details in error page

<img width="1920" height="1118" alt="image" src="https://github.com/user-attachments/assets/554fea39-bdb2-4435-8e98-4b1ff62991c2" />
